### PR TITLE
@craigspaeth => Boolean support and handle description

### DIFF
--- a/lib/map-field-asts.js
+++ b/lib/map-field-asts.js
@@ -64,17 +64,23 @@ const mapFieldASTs = (desc, selections) => {
   if (kinds === 'InlineFragment') {
     return selections.map((s) => mapFieldASTs(desc, s.selectionSet.selections))
   }
-  if (!desc) {
-    return { args: {}, fields: {} }
-  }
   const mapped = assign(...map(selections, (selection) => {
     const key = selection.name.value
     const args = validateArgs(desc, assign(...map(selection.arguments, (arg) =>
       ({ [arg.name.value]: selectionToValue(arg.value) }))))
-    const fields = selection.selectionSet
-      ? mapFieldASTs(desc.children, selection.selectionSet.selections)
-      : {}
-    return { [key]: { args, fields } }
+    if (desc && desc.items) {
+      let fields = map(desc.items, (desc) => {
+        selection.selectionSet
+          ? mapFieldASTs(desc.children, selection.selectionSet.selections)
+          : {}
+      })
+      return { [key]: { args, fields } }
+    } else {
+      let fields = selection.selectionSet
+        ? mapFieldASTs((desc.children), selection.selectionSet.selections)
+        : {}
+      return { [key]: { args, fields } }
+    }
   }))
   return mapped
 }

--- a/lib/map-field-asts.js
+++ b/lib/map-field-asts.js
@@ -64,7 +64,7 @@ const mapFieldASTs = (desc, selections) => {
   if (kinds === 'InlineFragment') {
     return selections.map((s) => mapFieldASTs(desc, s.selectionSet.selections))
   }
-  if(!desc){
+  if (!desc) {
     return { args: {}, fields: {} }
   }
   const mapped = assign(...map(selections, (selection) => {

--- a/lib/map-field-asts.js
+++ b/lib/map-field-asts.js
@@ -46,6 +46,7 @@ const selectionToValue = (selection) => {
   const fns = {
     IntValue: () => selection.value,
     StringValue: () => selection.value,
+    BooleanValue: () => selection.value,
     ListValue: () => map(selection.values, selectionToValue),
     ObjectValue: () => assign(...map(selection.fields, (field) =>
       ({ [field.name.value]: selectionToValue(field.value) })))

--- a/lib/map-field-asts.js
+++ b/lib/map-field-asts.js
@@ -64,6 +64,9 @@ const mapFieldASTs = (desc, selections) => {
   if (kinds === 'InlineFragment') {
     return selections.map((s) => mapFieldASTs(desc, s.selectionSet.selections))
   }
+  if(!desc){
+    return { args: {}, fields: {} }
+  }
   const mapped = assign(...map(selections, (selection) => {
     const key = selection.name.value
     const args = validateArgs(desc, assign(...map(selection.arguments, (arg) =>

--- a/lib/map-field-asts.js
+++ b/lib/map-field-asts.js
@@ -68,19 +68,19 @@ const mapFieldASTs = (desc, selections) => {
     const key = selection.name.value
     const args = validateArgs(desc, assign(...map(selection.arguments, (arg) =>
       ({ [arg.name.value]: selectionToValue(arg.value) }))))
+    let fields
     if (desc && desc.items) {
-      let fields = map(desc.items, (desc) => {
+      fields = map(desc.items, (desc) => {
         selection.selectionSet
           ? mapFieldASTs(desc.children, selection.selectionSet.selections)
           : {}
       })
-      return { [key]: { args, fields } }
     } else {
-      let fields = selection.selectionSet
+      fields = selection.selectionSet
         ? mapFieldASTs((desc.children), selection.selectionSet.selections)
         : {}
-      return { [key]: { args, fields } }
     }
+    return { [key]: { args, fields } }
   }))
   return mapped
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joiql",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Make GraphQL schema creation and data validation easy with Joi.",
   "main": "index.js",
   "scripts": {

--- a/test/map-field-asts.js
+++ b/test/map-field-asts.js
@@ -14,16 +14,26 @@ describe('mapFieldASTs', () => {
     const query = getQuery(
       object({
         hello: object({
-          world: string()
+          world: string(),
+          metadata: object({
+            email: string(),
+            name: string()
+          })
         })
       }),
       `{
         hello {
           world
+          metadata {
+            email
+            name
+          }
         }
       }`
     )
     query.hello.fields.world.fields.should.be.empty()
+    query.hello.fields.metadata.fields.email.fields.should.be.empty()
+    query.hello.fields.metadata.fields.name.fields.should.be.empty()
   })
 
   xit('validates arguments', () => {


### PR DESCRIPTION
The first commit is simple: adds boolean support to list of allowed GraphQL values.

The rest is what we worked on earlier today...and strangely everything works as far as I'm testing it. 😱 So now, it's only checking that desc exists and removes the other `if (desc.items)` stuff. I would like to understand why and how it's working so I'll continue to do some research and report back with more deets!
