### PR TITLE
State bug

### DIFF
--- a/lib/descs-to-fields.js
+++ b/lib/descs-to-fields.js
@@ -12,7 +12,8 @@ const {
   isEqual,
   debounce,
   assign,
-  flatten
+  flatten,
+  cloneDeep
 } = require('lodash')
 const {
   GraphQLString,
@@ -162,9 +163,12 @@ const descToType = (desc, isInput) => {
 // Convert a hash of descriptions into an object appropriate to put in a
 // GraphQL.js `fields` key.
 const descsToFields = (descs, resolveMiddlewares = () => {}) => {
-  const req = {}
+  let req = {}
   let finish
-  const aggregate = debounce(() => { finish = resolveMiddlewares(req) })
+  const aggregate = debounce(() => {
+    finish = resolveMiddlewares(cloneDeep(req))
+    req = {}
+  })
   return mapValues(descs, (desc, key) => ({
     type: descToType(desc),
     args: descToArgs(desc),

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,10 +3,9 @@
 // resolves the middleware in the order they were added via `.on`
 //
 const compose = require('koa-compose')
-const { cloneDeep } = require('lodash')
 
 exports.buildMiddlewares = (middlewares) => (req) => {
-  const ctx = cloneDeep({ res: {}, req, state: {} })
+  const ctx = { res: {}, req, state: {} }
   return compose(middlewares)(ctx).then(() => ctx.res)
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joiql",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Make GraphQL schema creation and data validation easy with Joi.",
   "main": "index.js",
   "scripts": {

--- a/test/descs-to-fields.js
+++ b/test/descs-to-fields.js
@@ -140,7 +140,7 @@ describe('descsToFields', () => {
 
   it('does not hold on to state', (done) => {
     const final = after(3, (req) => {
-      keys(req).join('').should.equal('bar')
+      keys(req).join('').should.equal('baz')
       done()
     })
     const fields = descsToFields({

--- a/test/descs-to-fields.js
+++ b/test/descs-to-fields.js
@@ -1,6 +1,16 @@
 /* eslint-env mocha */
 const descsToFields = require('../lib/descs-to-fields')
-const { string, number, object, array, boolean, date, alternatives } = require('joi')
+const { GraphQLSchema, GraphQLObjectType, graphql } = require('graphql')
+const {
+  string,
+  number,
+  object,
+  array,
+  boolean,
+  date,
+  alternatives
+} = require('joi')
+const { after, keys } = require('lodash')
 
 describe('descsToFields', () => {
   it('converts a joi string to GraphQL string', () => {
@@ -123,8 +133,31 @@ describe('descsToFields', () => {
     const blocks = fields.article.type._typeConfig.fields.blocks
     blocks.type.constructor.name.should.equal('GraphQLList')
     blocks.type.ofType.constructor.name.should.equal('GraphQLUnionType')
-    const [img, text] = blocks.type.ofType._types
+    const [img, text] = blocks.type.ofType._typeConfig.types
     img._typeConfig.fields.size.type.name.should.equal('Int')
     text._typeConfig.fields.body.type.name.should.equal('String')
+  })
+
+  it('does not hold on to state', (done) => {
+    const final = after(3, (req) => {
+      keys(req).join('').should.equal('bar')
+      done()
+    })
+    const fields = descsToFields({
+      foo: string().describe(),
+      bar: string().describe(),
+      baz: string().describe()
+    }, (req) => {
+      final(req)
+      return Promise.resolve()
+    })
+    const query = new GraphQLObjectType({
+      name: 'RootQueryType',
+      fields: fields
+    })
+    const schema = new GraphQLSchema({ query })
+    graphql(schema, '{ foo }')
+    setTimeout(() => graphql(schema, '{ bar }'), 10)
+    setTimeout(() => graphql(schema, '{ baz }'), 20)
   })
 })

--- a/test/descs-to-fields.js
+++ b/test/descs-to-fields.js
@@ -10,7 +10,7 @@ const {
   date,
   alternatives
 } = require('joi')
-const { after, keys } = require('lodash')
+const { after, keys, random } = require('lodash')
 
 describe('descsToFields', () => {
   it('converts a joi string to GraphQL string', () => {
@@ -140,16 +140,18 @@ describe('descsToFields', () => {
 
   it('does not hold on to state', (done) => {
     const final = after(3, (req) => {
-      keys(req).join('').should.equal('baz')
-      done()
+      keys(req).length.should.equal(1)
+      setTimeout(done, 10)
     })
     const fields = descsToFields({
       foo: string().describe(),
       bar: string().describe(),
       baz: string().describe()
     }, (req) => {
-      final(req)
-      return Promise.resolve()
+      return new Promise((resolve) => setTimeout(() => {
+        final(req)
+        resolve()
+      }, random(0, 50)))
     })
     const query = new GraphQLObjectType({
       name: 'RootQueryType',

--- a/test/integration.js
+++ b/test/integration.js
@@ -50,6 +50,4 @@ describe('joiql', () => {
       res.errors[0].message.should.containEql('child "age" fails')
     })
   })
-
-  it('clones ctx to avoid stateful bugs')
 })


### PR DESCRIPTION
Because of how we aggregate granular resolves into one big resolving of middleware—we have to store the state of the granular resolves in a `req` object that gets passed down the middleware at the end. Because we weren't reseting this `req` object after the middleware resolution, it was holding on to previous GraphQL request information. This resets that state and clones the `req` object to avoid that bug.

_State is the root of all evil_ as they say.
