### PR TITLE
Bump graphql dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,8 +151,8 @@ const validatedResolve = (schema) => (source, args, context, opts) => {
     const value = Joi.attempt(args, argsSchema)
     return resolve(source, value, context, opts)
   }
-  else return source && source[opts.fieldASTs[0].name.value]
   if (resolve) return resolve(source, args, context, opts)
+  else return source && source[opts.fieldNodes[0].name.value]
 }
 
 // Convert a hash of descriptions into an object appropriate to put in a

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const {
   flatten,
   isEmpty,
   mapValues,
+  omit,
   omitBy,
   isNull,
   fromPairs,
@@ -108,7 +109,12 @@ const makeArrayAlternativeType = (cachedTypes, isInput, typeName, desc, items) =
     return cachedTypes[typeName]
   } else if (isInput) {
     const children = fromPairs(flatten(items.map((item) => map(item._inner.children, (c) => [c.key, c.schema]))))
-    const fields = descsToFields(children)
+
+    // Strip resolvers from generated types
+    const fields = mapValues(descsToFields(children), (field) => {
+      return omit(field, 'resolve');
+    });
+
     return new GraphQLInputObjectType({
       name: typeName,
       description: desc.description,

--- a/index.js
+++ b/index.js
@@ -143,16 +143,16 @@ const descToArgs = (schema) => {
 }
 
 // Wraps a resolve function specifid in a Joi schema to add validation.
-const validatedResolve = (schema) => (source, args, root, opts) => {
+const validatedResolve = (schema) => (source, args, context, opts) => {
   const desc = schema.describe()
   const resolve = desc.meta && first(compact(map(desc.meta, 'resolve')))
   if (args && !isEmpty(args)) {
     const argsSchema = first(compact(map(desc.meta, 'args')))
     const value = Joi.attempt(args, argsSchema)
-    return resolve(source, value, root, opts)
+    return resolve(source, value, context, opts)
   }
-  if (resolve) return resolve(source, args, root, opts)
   else return source && source[opts.fieldASTs[0].name.value]
+  if (resolve) return resolve(source, args, context, opts)
 }
 
 // Convert a hash of descriptions into an object appropriate to put in a

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "graphql": "^0.7.2",
+    "graphql": "^0.11.7",
     "lodash": "^4.13.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Introduction

This pull requests bumps the graphql dependency version to ^0.11.7. The primary motivation for this pull request is that the newer versions of graphql-js are not backwards compatible and cause fun, difficult to trace problems such as those described [here](https://github.com/graphql/graphql-js/issues/1016).

### Changes

No functional changes, but the following modifications were made to make joiql comply with the newer version of graphql: 

* Resolvers are stripped from input types. I assume that graphql was ignoring them previously and now throws an error if they are provided.
* `fieldASTs` in the `opts` / `info` / fourth argument to `resolve` has been renamed to `fieldNodes`.